### PR TITLE
Update deprecated ehrQL methods

### DIFF
--- a/analysis/dataset_definition.py
+++ b/analysis/dataset_definition.py
@@ -45,14 +45,14 @@ firstmoderna_date = study_dates["firstmoderna_date"]
 # The old study def used 1900 as a minimum date so we replicate that here; but I think
 # it only did this because it had to supply _some_ minimum date, which we don't need to
 # here, so maybe we can drop this.
-vax = schema.vaccinations.take(schema.vaccinations.date.is_after("1900-01-01"))
+vax = schema.vaccinations.where(schema.vaccinations.date.is_after("1900-01-01"))
 
 # Pfizer
 create_sequential_variables(
     dataset,
     "covid_vax_pfizer_{n}_date",
     num_variables=4,
-    events=vax.take(
+    events=vax.where(
         vax.product_name
         == "COVID-19 mRNA Vaccine Comirnaty 30micrograms/0.3ml dose conc for susp for inj MDV (Pfizer)"
     ),
@@ -64,7 +64,7 @@ create_sequential_variables(
     dataset,
     "covid_vax_az_{n}_date",
     num_variables=4,
-    events=vax.take(
+    events=vax.where(
         vax.product_name
         == "COVID-19 Vaccine Vaxzevria 0.5ml inj multidose vials (AstraZeneca)"
     ),
@@ -76,7 +76,7 @@ create_sequential_variables(
     dataset,
     "covid_vax_moderna_{n}_date",
     num_variables=4,
-    events=vax.take(
+    events=vax.where(
         vax.product_name
         == "COVID-19 mRNA Vaccine Spikevax (nucleoside modified) 0.1mg/0.5mL dose disp for inj MDV (Moderna)"
     ),
@@ -88,7 +88,7 @@ create_sequential_variables(
     dataset,
     "covid_vax_disease_{n}_date",
     num_variables=4,
-    events=vax.take(vax.target_disease == "SARS-2 CORONAVIRUS"),
+    events=vax.where(vax.target_disease == "SARS-2 CORONAVIRUS"),
     column="date",
 )
 
@@ -104,22 +104,22 @@ baseline_date = boosted_date - days(1)
 
 events = schema.clinical_events
 meds = schema.medications
-prior_events = events.take(events.date.is_on_or_before(baseline_date))
-prior_meds = meds.take(meds.date.is_on_or_before(baseline_date))
+prior_events = events.where(events.date.is_on_or_before(baseline_date))
+prior_meds = meds.where(meds.date.is_on_or_before(baseline_date))
 
 
 def has_prior_event(codelist, where=True):
     return (
-        prior_events.take(where)
-        .take(prior_events.snomedct_code.is_in(codelist))
+        prior_events.where(where)
+        .where(prior_events.snomedct_code.is_in(codelist))
         .exists_for_patient()
     )
 
 
 def last_prior_event(codelist, where=True):
     return (
-        prior_events.take(where)
-        .take(prior_events.snomedct_code.is_in(codelist))
+        prior_events.where(where)
+        .where(prior_events.snomedct_code.is_in(codelist))
         .sort_by(events.date)
         .last_for_patient()
     )
@@ -127,8 +127,8 @@ def last_prior_event(codelist, where=True):
 
 def has_prior_meds(codelist, where=True):
     return (
-        prior_meds.take(where)
-        .take(prior_meds.dmd_code.is_in(codelist))
+        prior_meds.where(where)
+        .where(prior_meds.dmd_code.is_in(codelist))
         .exists_for_patient()
     )
 
@@ -170,7 +170,7 @@ dataset.bmi = case(
 
 # Ethnicity in 6 categories
 dataset.ethnicity = (
-    events.take(events.ctv3_code.is_in(codelists.ethnicity))
+    events.where(events.ctv3_code.is_in(codelists.ethnicity))
     .sort_by(events.date)
     .last_for_patient()
     .ctv3_code.to_category(codelists.ethnicity)
@@ -235,7 +235,7 @@ dataset.imd_Q5 = case(
 
 # Health or social care worker
 vaxx_job = schema.occupation_on_covid_vaccine_record
-dataset.hscworker = vaxx_job.take(vaxx_job.is_healthcare_worker).exists_for_patient()
+dataset.hscworker = vaxx_job.where(vaxx_job.is_healthcare_worker).exists_for_patient()
 
 # TPP care home flag
 dataset.care_home_tpp = case(
@@ -250,7 +250,7 @@ dataset.care_home_code = has_prior_event(codelists.carehome)
 # Pre-baseline events where event date is of interest
 #######################################################################################
 
-primary_care_covid_events = events.take(
+primary_care_covid_events = events.where(
     events.ctv3_code.is_in(
         codelists.covid_primary_care_code
         + codelists.covid_primary_care_positive_test
@@ -259,7 +259,7 @@ primary_care_covid_events = events.take(
 )
 
 dataset.primary_care_covid_case_0_date = (
-    primary_care_covid_events.take(events.date.is_on_or_before(baseline_date))
+    primary_care_covid_events.where(events.date.is_on_or_before(baseline_date))
     .sort_by(events.date)
     .last_for_patient()
     .date
@@ -267,11 +267,11 @@ dataset.primary_care_covid_case_0_date = (
 
 # Covid test dates from SGSS
 covid_tests = schema.sgss_covid_all_tests
-prior_tests = covid_tests.take(
+prior_tests = covid_tests.where(
     covid_tests.specimen_taken_date.is_on_or_before(baseline_date)
 )
 dataset.covid_test_0_date = prior_tests.specimen_taken_date.maximum_for_patient()
-dataset.postest_0_date = prior_tests.take(
+dataset.postest_0_date = prior_tests.where(
     prior_tests.is_positive
 ).specimen_taken_date.maximum_for_patient()
 
@@ -281,7 +281,7 @@ emerg_care = schema.emergency_care_attendances
 
 dataset.covidemergency_0_date = (
     emergency_care_diagnosis_matches(emerg_care, codelists.covid_emergency)
-    .take(emerg_care.arrival_date.is_on_or_before(baseline_date))
+    .where(emerg_care.arrival_date.is_on_or_before(baseline_date))
     .sort_by(emerg_care.arrival_date)
     .last_for_patient()
     .arrival_date
@@ -293,8 +293,8 @@ hosp = schema.hospital_admissions
 
 dataset.covidadmitted_0_date = (
     hospitalisation_diagnosis_matches(hosp, codelists.covid_icd10)
-    .take(hosp.admission_date.is_on_or_before(baseline_date))
-    .take(
+    .where(hosp.admission_date.is_on_or_before(baseline_date))
+    .where(
         hosp.admission_method.is_in(
             ["21", "22", "23", "24", "25", "2A", "2B", "2C", "2D", "28"]
         )
@@ -508,15 +508,15 @@ dataset.housebound = (
     housebound_date.is_not_null() & ~no_longer_housebound & ~moved_into_care_home
 )
 
-dataset.prior_covid_test_frequency = prior_tests.take(
+dataset.prior_covid_test_frequency = prior_tests.where(
     prior_tests.specimen_taken_date.is_after(baseline_date - days(26 * 7))
 ).count_for_patient()
 
 # Overnight hospital admission at time of 3rd / booster dose
 dataset.inhospital = (
-    hosp.take(hosp.admission_date.is_on_or_before(boosted_date))
-    .take(hosp.discharge_date.is_on_or_after(boosted_date))
-    .take(
+    hosp.where(hosp.admission_date.is_on_or_before(boosted_date))
+    .where(hosp.discharge_date.is_on_or_after(boosted_date))
+    .where(
         # See https://github.com/opensafely-core/cohort-extractor/pull/497 for codes
         # See https://docs.opensafely.org/study-def-variables/#sus for more info
         hosp.admission_method.is_in(
@@ -538,7 +538,7 @@ dataset.inhospital = (
         )
     )
     # Ordinary admissions only
-    .take(hosp.patient_classification == "1")
+    .where(hosp.patient_classification == "1")
     .exists_for_patient()
 )
 
@@ -549,19 +549,19 @@ dataset.inhospital = (
 
 # Positive case identification after study start date
 dataset.primary_care_covid_case_date = (
-    primary_care_covid_events.take(events.date.is_on_or_after(boosted_date))
+    primary_care_covid_events.where(events.date.is_on_or_after(boosted_date))
     .sort_by(events.date)
     .first_for_patient()
     .date
 )
 
 # Covid test dates from SGSS
-post_baseline_tests = covid_tests.take(
+post_baseline_tests = covid_tests.where(
     covid_tests.specimen_taken_date.is_on_or_after(boosted_date)
 )
 dataset.covid_tests_date = post_baseline_tests.specimen_taken_date.minimum_for_patient()
 # Positive covid test
-dataset.postest_date = post_baseline_tests.take(
+dataset.postest_date = post_baseline_tests.where(
     post_baseline_tests.is_positive
 ).specimen_taken_date.minimum_for_patient()
 
@@ -574,8 +574,8 @@ def post_baseline_ec_date(diagnoses=None, where=True):
             if diagnoses
             else emerg_care
         )
-        .take(emerg_care.arrival_date.is_on_or_after(boosted_date))
-        .take(where)
+        .where(emerg_care.arrival_date.is_on_or_after(boosted_date))
+        .where(where)
         .sort_by(emerg_care.arrival_date)
         .first_for_patient()
         .arrival_date
@@ -629,10 +629,10 @@ dataset.emergencyhosp_date = post_baseline_ec_date(
 def post_baseline_admission_date(codelist=None, where=True):
     return (
         (hospitalisation_diagnosis_matches(hosp, codelist) if codelist else hosp)
-        .take(hosp.admission_date.is_on_or_after(boosted_date))
+        .where(hosp.admission_date.is_on_or_after(boosted_date))
         # Ordinary admissions only
-        .take(hosp.patient_classification == "1")
-        .take(where)
+        .where(hosp.patient_classification == "1")
+        .where(where)
         .sort_by(hosp.admission_date)
         .first_for_patient()
         .admission_date
@@ -663,12 +663,12 @@ dataset.covidadmitted_date = post_baseline_admission_date(
 # hospitalisations after study start
 covid_admissions = (
     hospitalisation_diagnosis_matches(hosp, codelists.covid_icd10)
-    .take(
+    .where(
         hosp.admission_method.is_in(
             ["21", "22", "23", "24", "25", "2A", "2B", "2C", "2D", "28"]
         )
     )
-    .take(hosp.admission_date.is_on_or_after(boosted_date))
+    .where(hosp.admission_date.is_on_or_after(boosted_date))
 )
 
 create_sequential_variables(
@@ -695,7 +695,7 @@ create_sequential_variables(
 
 registered = practice_registration_as_of(baseline_date).exists_for_patient()
 
-dataset.set_population(
+dataset.define_population(
     registered
     & (dataset.age_august2021 >= 18)
     & boosted_date.is_on_or_after(studystart_date)

--- a/analysis/test_variables_lib.py
+++ b/analysis/test_variables_lib.py
@@ -21,9 +21,9 @@ def test_create_sequential_variables(in_memory_engine):
     )
 
     dataset = Dataset()
-    dataset.set_population(events.exists_for_patient())
+    dataset.define_population(events.exists_for_patient())
 
-    frame = events.take(events.date.is_on_or_after("2020-04-01"))
+    frame = events.where(events.date.is_on_or_after("2020-04-01"))
     create_sequential_variables(
         dataset, "date_{n}", frame, column="date", num_variables=3
     )
@@ -64,9 +64,9 @@ def test_create_sequential_variables_with_different_sort_column(in_memory_engine
     )
 
     dataset = Dataset()
-    dataset.set_population(events.exists_for_patient())
+    dataset.define_population(events.exists_for_patient())
 
-    frame = events.take(events.date.is_on_or_after("2020-04-01"))
+    frame = events.where(events.date.is_on_or_after("2020-04-01"))
     create_sequential_variables(
         dataset, "value_{n}", frame, column="value", sort_column="date", num_variables=3
     )


### PR DESCRIPTION
The following ehrQL methods have been updated:
- `.take` is now `.where` 
- `.drop` is now `.except_where` 
- `set_population` is now `.define_population`